### PR TITLE
feat: detect Talos OS, extension, kernel-arg, and Kubernetes drift in diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ go install github.com/mirceanton/talstomize/cmd/talstomize@latest
    talstomize apply -f . -- --insecure --dry-run   # multiple flags at once
    ```
 
-5. Or check what would change before applying anything:
+5. Or check what would change before applying anything - and, importantly, whether a
+   `talosVersion`/`kubernetesVersion`/`schematic` bump you already `apply`'d actually took
+   effect:
 
    ```shell
    talstomize diff -f .                # every node
@@ -117,14 +119,31 @@ go install github.com/mirceanton/talstomize/cmd/talstomize@latest
         install:
    -        image: ghcr.io/siderolabs/installer:v1.9.5
    +        image: ghcr.io/siderolabs/installer:v1.9.6
+       talos: running v1.13.7, want v1.13.8 (ghcr.io/siderolabs/installer:v1.13.8)
+       extensions: missing [qemu-guest-agent]
+       kernel args: missing [amdgpu.gttsize=40960]
    ==> nodeb (10.5.0.12): no differences
+   ==> kubernetes: running 1.36.2, want 1.36.3
    ```
 
    Exits `0` if every node matches, `1` if any node differs (or on error) -
    safe to use in a script or CI check.
 
 >[!IMPORTANT]
-> `apply` and `diff` are thin wrappers. `apply` renders each node's config the same way `build` does, then runs `talosctl apply-config --nodes <ip> --file <rendered>` for it. `diff` renders it the same way, fetches the node's currently running config via `talosctl get machineconfig --nodes <ip> -o yaml`, and diffs the two (encoded without comments, so the diff isn't swamped by Talos's per-field documentation).  
+> `apply` and `diff` are thin wrappers around `talosctl`, and neither one ever runs
+> `talosctl upgrade`/`upgrade-k8s` itself - actually upgrading a node's Talos OS or the
+> cluster's Kubernetes version is always a deliberate, manual step outside talstomize.
+> `apply` renders each node's config the same way `build` does, then runs
+> `talosctl apply-config --nodes <ip> --file <rendered>` for it - this reconciles machine
+> config, nothing more. `diff` renders the same way and reports every difference between
+> that and live cluster state: the running machine config (`talosctl get machineconfig`,
+> encoded without comments so the diff isn't swamped by Talos's own per-field
+> documentation), the node's actual booted Talos OS version (`talosctl get version` -
+> deliberately *not* the machine config's own `install.image` field, which only reflects
+> last-declared intent and can already agree with the rendered config even when the node
+> was never actually rebooted), and - if `installer.schematic` is set - its installed
+> system extensions and kernel args (`talosctl get extensions`/`get cmdline`), plus the
+> cluster's running Kubernetes version (`talosctl upgrade-k8s --dry-run`), once, cluster-wide.  
 > Everything after `--` is passed straight through to the underlying `talosctl` invocation, so any of its flags work (`--insecure`, `--dry-run`, `--mode`, `--talosconfig`, `--endpoints`, ...) without talstomize needing to know about them.
 
 See [`examples/simple`](./examples/simple) for a complete working example.

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -80,12 +79,7 @@ func newApplyCommand() *cobra.Command {
 
 				fmt.Fprintf(cmd.OutOrStdout(), "==> applying config to %s (%s)\n", name, node.IP)
 
-				run := exec.Command("talosctl", talosctlArgs...)
-				run.Stdout = cmd.OutOrStdout()
-				run.Stderr = cmd.ErrOrStderr()
-				run.Stdin = os.Stdin
-
-				if err := run.Run(); err != nil {
+				if err := runTalosctlStreaming(cmd.OutOrStdout(), cmd.ErrOrStderr(), talosctlArgs); err != nil {
 					return fmt.Errorf("applying config to node %q (%s): %w", name, node.IP, err)
 				}
 			}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,11 +1,10 @@
 package cli
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -27,9 +26,15 @@ func newDiffCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff [-- talosctl flags]",
 		Short: "Diff each node's rendered config against its running config",
-		Long: "Render each node's machine config the same way `build` does, fetch its currently " +
-			"running config with `talosctl get machineconfig`, and print the difference. Requires " +
-			"talosctl to be installed and on PATH.\n\n" +
+		Long: "Render each node's machine config the same way `build` does, and compare it " +
+			"against live cluster state: the running machine config, the node's actual Talos OS " +
+			"version, its installed system extensions and kernel args (if a schematic is " +
+			"configured), and the cluster's running Kubernetes version. Requires talosctl to be " +
+			"installed and on PATH.\n\n" +
+			"This only detects drift - it never upgrades anything. A version bump in " +
+			"talstomize.yaml (talosVersion, kubernetesVersion, or a schematic change) only takes " +
+			"effect once you actually run `talosctl upgrade`/`upgrade-k8s` yourself; `diff` is how " +
+			"you find out that's still pending after `apply`.\n\n" +
 			"Anything after `--` is passed through to talosctl as-is, e.g.\n" +
 			"  talstomize diff -f . -- --insecure\n\n" +
 			"Exits 0 if every node matches, 1 if any node differs (or on error).",
@@ -61,6 +66,7 @@ func newDiffCommand() *cobra.Command {
 			}
 
 			out := cmd.OutOrStdout()
+			errOut := cmd.ErrOrStderr()
 			anyDiff := false
 
 			for _, name := range names {
@@ -71,17 +77,22 @@ func newDiffCommand() *cobra.Command {
 					return err
 				}
 
-				running, err := getRunningConfig(node.IP, passthrough, cmd.ErrOrStderr())
+				running, err := getRunningConfig(node.IP, passthrough, errOut)
 				if err != nil {
 					return fmt.Errorf("node %q: fetching running config: %w", name, err)
 				}
 
-				diff, err := configdiff.DiffConfigs(running, rendered)
+				configDiff, err := configdiff.DiffConfigs(running, rendered)
 				if err != nil {
 					return fmt.Errorf("node %q: diffing: %w", name, err)
 				}
 
-				if diff == "" {
+				extraLines, err := diffLiveState(engine, node, rendered, errOut, name, passthrough)
+				if err != nil {
+					return err
+				}
+
+				if configDiff == "" && len(extraLines) == 0 {
 					fmt.Fprintf(out, "==> %s (%s): no differences\n", name, node.IP)
 
 					continue
@@ -89,7 +100,26 @@ func newDiffCommand() *cobra.Command {
 
 				anyDiff = true
 
-				fmt.Fprintf(out, "==> %s (%s):\n%s\n", name, node.IP, diff)
+				fmt.Fprintf(out, "==> %s (%s):\n", name, node.IP)
+
+				if configDiff != "" {
+					fmt.Fprintln(out, configDiff)
+				}
+
+				for _, line := range extraLines {
+					fmt.Fprintln(out, line)
+				}
+			}
+
+			k8sDrift, err := diffKubernetesVersion(engine, errOut, passthrough)
+			if err != nil {
+				return err
+			}
+
+			if k8sDrift != "" {
+				anyDiff = true
+
+				fmt.Fprintf(out, "==> kubernetes: %s\n", k8sDrift)
 			}
 
 			if anyDiff {
@@ -115,21 +145,16 @@ func newDiffCommand() *cobra.Command {
 func getRunningConfig(ip string, passthrough []string, stderr io.Writer) (tconfig.Provider, error) {
 	args := append([]string{"get", "machineconfig", "--nodes", ip, "-o", "yaml"}, passthrough...)
 
-	var stdout bytes.Buffer
-
-	run := exec.Command("talosctl", args...)
-	run.Stdout = &stdout
-	run.Stderr = stderr
-
-	if err := run.Run(); err != nil {
-		return nil, fmt.Errorf("talosctl get machineconfig: %w", err)
+	stdout, err := runTalosctlCaptured(stderr, args)
+	if err != nil {
+		return nil, err
 	}
 
 	var resource struct {
 		Spec string `yaml:"spec"`
 	}
 
-	if err := yaml.NewDecoder(&stdout).Decode(&resource); err != nil {
+	if err := yaml.Unmarshal([]byte(stdout), &resource); err != nil {
 		return nil, fmt.Errorf("parsing machineconfig resource: %w", err)
 	}
 
@@ -143,4 +168,101 @@ func getRunningConfig(ip string, passthrough []string, stderr io.Writer) (tconfi
 	}
 
 	return provider, nil
+}
+
+// diffLiveState compares node's actual live state against what rendered
+// declares - its running Talos OS version, and, if a schematic is
+// configured (Engine.EffectiveCustomization), its installed system
+// extensions and kernel args - returning one line per check that found
+// drift (nil if everything matches). This is what a plain machine-config
+// diff can't catch: bumping installer.talosVersion and applying config
+// only changes the *declared* install image, not what's actually booted -
+// the two can already agree with each other while the real node is still
+// on the old version.
+func diffLiveState(engine *talos.Engine, node config.Node, rendered tconfig.Provider, errOut io.Writer, name string, passthrough []string) ([]string, error) {
+	var lines []string
+
+	if target := rendered.Machine().Install().Image(); target != "" {
+		running, err := getRunningTalosVersion(errOut, node.IP, passthrough)
+		if err != nil {
+			return nil, fmt.Errorf("node %q: fetching running Talos version: %w", name, err)
+		}
+
+		if drifted, ok := talos.TalosVersionDrift(running, target); ok && drifted {
+			lines = append(lines, fmt.Sprintf("    talos: running %s, want %s (%s)", running, talos.ImageTag(target), target))
+		}
+	}
+
+	customization, ok, err := engine.EffectiveCustomization(node)
+	if err != nil {
+		return nil, fmt.Errorf("node %q: resolving schematic: %w", name, err)
+	}
+
+	if !ok {
+		return lines, nil
+	}
+
+	installed, err := getInstalledExtensions(errOut, node.IP, passthrough)
+	if err != nil {
+		return nil, fmt.Errorf("node %q: fetching installed extensions: %w", name, err)
+	}
+
+	desiredExtensions := customization.Customization.SystemExtensions.OfficialExtensions
+	if missing, unexpected := talos.ExtensionDrift(installed, desiredExtensions); len(missing) > 0 || len(unexpected) > 0 {
+		var parts []string
+
+		if len(missing) > 0 {
+			parts = append(parts, fmt.Sprintf("missing %v", missing))
+		}
+
+		if len(unexpected) > 0 {
+			parts = append(parts, fmt.Sprintf("unexpected %v", unexpected))
+		}
+
+		lines = append(lines, "    extensions: "+strings.Join(parts, ", "))
+	}
+
+	cmdline, err := getKernelCmdline(errOut, node.IP, passthrough)
+	if err != nil {
+		return nil, fmt.Errorf("node %q: fetching kernel cmdline: %w", name, err)
+	}
+
+	desiredArgs := customization.Customization.ExtraKernelArgs
+	if missing := talos.KernelArgDrift(cmdline, desiredArgs); len(missing) > 0 {
+		lines = append(lines, fmt.Sprintf("    kernel args: missing %v", missing))
+	}
+
+	return lines, nil
+}
+
+// diffKubernetesVersion reports whether the cluster's running Kubernetes
+// version differs from target (Engine.KubernetesVersion), returning a
+// one-line "running X, want Y" summary if so, "" if the cluster is
+// already at target.
+//
+// `talosctl upgrade-k8s --dry-run`'s plan output turns out not to be a
+// usable "is there drift" signal on its own - live-verified against a
+// real cluster already sitting at the target version, it still
+// unconditionally prints "updating <component> to version ..." action
+// lines and a manifest-annotation diff (SSA ownership metadata churn
+// unrelated to version drift). The one reliable signal in it is the
+// auto-detected current version, parsed via talos.ParseKubernetesVersion.
+func diffKubernetesVersion(engine *talos.Engine, errOut io.Writer, passthrough []string) (string, error) {
+	target := engine.KubernetesVersion()
+
+	plan, err := getK8sUpgradePlan(errOut, target, passthrough)
+	if err != nil {
+		return "", fmt.Errorf("fetching Kubernetes upgrade plan: %w", err)
+	}
+
+	running := talos.ParseKubernetesVersion(plan)
+	if running == "" {
+		return "", fmt.Errorf("could not determine the cluster's current Kubernetes version from talosctl upgrade-k8s --dry-run output")
+	}
+
+	if running == target {
+		return "", nil
+	}
+
+	return fmt.Sprintf("running %s, want %s", running, target), nil
 }

--- a/internal/cli/liveinfo.go
+++ b/internal/cli/liveinfo.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// getRunningTalosVersion fetches the Talos OS version currently *running*
+// on the node at ip - its live `version` runtime resource (spec.version,
+// e.g. "v1.13.7") - not the version implied by its last-applied (and
+// possibly stale) machine config.
+func getRunningTalosVersion(errOut io.Writer, ip string, passthrough []string) (string, error) {
+	args := append([]string{"get", "version", "--nodes", ip, "-o", "yaml"}, passthrough...)
+
+	stdout, err := runTalosctlCaptured(errOut, args)
+	if err != nil {
+		return "", err
+	}
+
+	var resource struct {
+		Spec struct {
+			Version string `yaml:"version"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal([]byte(stdout), &resource); err != nil {
+		return "", fmt.Errorf("parsing version resource: %w", err)
+	}
+
+	return resource.Spec.Version, nil
+}
+
+// syntheticExtensionNames are entries `talosctl get extensions` always
+// reports alongside real, user-declared ones, regardless of what's in a
+// schematic's officialExtensions list - "schematic" is Talos's own
+// bookkeeping record of the schematic itself, "modules.dep" an
+// auto-generated kernel-module dependency layer. Live-verified against a
+// real node: both appear even though neither is (or could be) a
+// legitimate officialExtensions entry. Excluded so ExtensionDrift's
+// "unexpected" check doesn't flag them on every node.
+var syntheticExtensionNames = map[string]bool{
+	"schematic":   true,
+	"modules.dep": true,
+}
+
+// getInstalledExtensions fetches the names of every real system extension
+// currently installed on the node at ip, from its live `extensions`
+// runtime resources - one COSI document per installed extension, unlike
+// the single-resource cases above.
+func getInstalledExtensions(errOut io.Writer, ip string, passthrough []string) ([]string, error) {
+	args := append([]string{"get", "extensions", "--nodes", ip, "-o", "yaml"}, passthrough...)
+
+	stdout, err := runTalosctlCaptured(errOut, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseInstalledExtensions(stdout)
+}
+
+// parseInstalledExtensions decodes `talosctl get extensions -o yaml`'s
+// multi-document YAML stream (one COSI resource per installed extension)
+// into a list of names, filtering out Talos-internal synthetic entries
+// (see syntheticExtensionNames) so ExtensionDrift's "unexpected" check
+// doesn't flag them on every node.
+func parseInstalledExtensions(yamlStream string) ([]string, error) {
+	dec := yaml.NewDecoder(strings.NewReader(yamlStream))
+
+	var names []string
+
+	for {
+		var resource struct {
+			Spec struct {
+				Metadata struct {
+					Name string `yaml:"name"`
+				} `yaml:"metadata"`
+			} `yaml:"spec"`
+		}
+
+		err := dec.Decode(&resource)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("parsing extension resource: %w", err)
+		}
+
+		if name := resource.Spec.Metadata.Name; name != "" && !syntheticExtensionNames[name] {
+			names = append(names, name)
+		}
+	}
+
+	return names, nil
+}
+
+// getKernelCmdline fetches the live kernel command line (contents of
+// /proc/cmdline as actually booted) from the node at ip's `cmdline`
+// runtime resource.
+func getKernelCmdline(errOut io.Writer, ip string, passthrough []string) (string, error) {
+	args := append([]string{"get", "cmdline", "--nodes", ip, "-o", "yaml"}, passthrough...)
+
+	stdout, err := runTalosctlCaptured(errOut, args)
+	if err != nil {
+		return "", err
+	}
+
+	var resource struct {
+		Spec struct {
+			Cmdline string `yaml:"cmdline"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal([]byte(stdout), &resource); err != nil {
+		return "", fmt.Errorf("parsing cmdline resource: %w", err)
+	}
+
+	return resource.Spec.Cmdline, nil
+}
+
+// getK8sUpgradePlan runs `talosctl upgrade-k8s --to target --dry-run` and
+// returns its raw stdout - used only to detect/report whether the
+// cluster's current Kubernetes version differs from target, never to
+// execute anything.
+func getK8sUpgradePlan(errOut io.Writer, target string, passthrough []string) (string, error) {
+	args := append([]string{"upgrade-k8s", "--to", target, "--dry-run"}, passthrough...)
+
+	return runTalosctlCaptured(errOut, args)
+}

--- a/internal/cli/liveinfo_test.go
+++ b/internal/cli/liveinfo_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+)
+
+// realExtensionsYAML is a trimmed but otherwise verbatim capture of
+// `talosctl get extensions -o yaml` against a real node - three real
+// extensions plus the two Talos-internal synthetic entries
+// (syntheticExtensionNames) that appear on every node regardless of what
+// the schematic actually declares.
+const realExtensionsYAML = `node: 10.0.0.15
+metadata:
+    namespace: runtime
+    type: ExtensionStatuses.runtime.talos.dev
+    id: "0"
+    version: 1
+spec:
+    image: 0.sqsh
+    metadata:
+        name: amd-ucode
+        version: "20260622"
+---
+node: 10.0.0.15
+metadata:
+    namespace: runtime
+    type: ExtensionStatuses.runtime.talos.dev
+    id: "1"
+    version: 1
+spec:
+    image: 1.sqsh
+    metadata:
+        name: amdgpu
+        version: 20260622-v1.13.7
+---
+node: 10.0.0.15
+metadata:
+    namespace: runtime
+    type: ExtensionStatuses.runtime.talos.dev
+    id: "2"
+    version: 1
+spec:
+    image: 2.sqsh
+    metadata:
+        name: nvidia-container-toolkit-production
+        version: 595.71.05-v1.19.1
+---
+node: 10.0.0.15
+metadata:
+    namespace: runtime
+    type: ExtensionStatuses.runtime.talos.dev
+    id: "9"
+    version: 1
+spec:
+    image: 9.sqsh
+    metadata:
+        name: schematic
+---
+node: 10.0.0.15
+metadata:
+    namespace: runtime
+    type: ExtensionStatuses.runtime.talos.dev
+    id: "10"
+    version: 1
+spec:
+    image: modules.dep.sqsh
+    metadata:
+        name: modules.dep
+`
+
+func TestParseInstalledExtensionsFiltersSyntheticNames(t *testing.T) {
+	got, err := parseInstalledExtensions(realExtensionsYAML)
+	if err != nil {
+		t.Fatalf("parseInstalledExtensions: %v", err)
+	}
+
+	want := []string{"amd-ucode", "amdgpu", "nvidia-container-toolkit-production"}
+	if !slices.Equal(got, want) {
+		t.Errorf("parseInstalledExtensions(...) = %v, want %v (schematic/modules.dep should be filtered)", got, want)
+	}
+}
+
+func TestParseInstalledExtensionsEmpty(t *testing.T) {
+	got, err := parseInstalledExtensions("")
+	if err != nil {
+		t.Fatalf("parseInstalledExtensions: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("parseInstalledExtensions(\"\") = %v, want empty", got)
+	}
+}
+
+func TestParseInstalledExtensionsMalformed(t *testing.T) {
+	if _, err := parseInstalledExtensions("not: [valid, yaml"); err == nil {
+		t.Fatal("parseInstalledExtensions: expected an error for malformed YAML, got nil")
+	}
+}

--- a/internal/cli/talosctl.go
+++ b/internal/cli/talosctl.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// runTalosctlStreaming runs talosctl with args, streaming stdout/stderr
+// live to out/errOut and connecting os.Stdin - for long-running or
+// interactive subcommands (apply-config, upgrade, upgrade-k8s) where the
+// caller wants to watch progress as it happens rather than parse a result.
+func runTalosctlStreaming(out, errOut io.Writer, args []string) error {
+	run := exec.Command("talosctl", args...)
+	run.Stdout = out
+	run.Stderr = errOut
+	run.Stdin = os.Stdin
+
+	if err := run.Run(); err != nil {
+		return fmt.Errorf("talosctl %s: %w", subcommandLabel(args), err)
+	}
+
+	return nil
+}
+
+// runTalosctlCaptured runs talosctl with args, streaming only stderr live
+// and returning stdout as a string for the caller to parse - for
+// subcommands whose output needs to be read as a unit (get machineconfig,
+// get version, get extensions, get cmdline, upgrade-k8s --dry-run).
+func runTalosctlCaptured(errOut io.Writer, args []string) (string, error) {
+	var stdout bytes.Buffer
+
+	run := exec.Command("talosctl", args...)
+	run.Stdout = &stdout
+	run.Stderr = errOut
+
+	if err := run.Run(); err != nil {
+		return "", fmt.Errorf("talosctl %s: %w", subcommandLabel(args), err)
+	}
+
+	return stdout.String(), nil
+}
+
+// subcommandLabel returns a short, human-readable label for an error
+// message - the leading non-flag tokens of args, e.g. "apply-config" or
+// "get machineconfig", not the full argument list (which would include
+// node IPs and file paths).
+func subcommandLabel(args []string) string {
+	var words []string
+
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") || len(words) >= 2 {
+			break
+		}
+
+		words = append(words, a)
+	}
+
+	return strings.Join(words, " ")
+}

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -23,6 +23,18 @@ var (
 	httpClient = &http.Client{Timeout: 30 * time.Second}
 )
 
+// Customization is the subset of a schematic customization document
+// talstomize reads back out (e.g. to compare against what's actually
+// installed on a node), rather than just posting opaquely to the Factory.
+type Customization struct {
+	Customization struct {
+		ExtraKernelArgs  []string `yaml:"extraKernelArgs"`
+		SystemExtensions struct {
+			OfficialExtensions []string `yaml:"officialExtensions"`
+		} `yaml:"systemExtensions"`
+	} `yaml:"customization"`
+}
+
 // Schematic posts a schematic customization document (extraKernelArgs,
 // systemExtensions, ...) to the Image Factory and returns the resulting
 // schematic ID. The same customization always produces the same ID - the

--- a/internal/talos/drift.go
+++ b/internal/talos/drift.go
@@ -1,0 +1,131 @@
+package talos
+
+import (
+	"regexp"
+	"strings"
+)
+
+var detectedKubernetesVersionRE = regexp.MustCompile(`automatically detected the lowest Kubernetes version (\S+)`)
+
+// ParseKubernetesVersion extracts the auto-detected current Kubernetes
+// version from `talosctl upgrade-k8s --dry-run`'s output (the line
+// "automatically detected the lowest Kubernetes version X"). Live-verified
+// against a real cluster: that line is present on every successful
+// dry-run regardless of whether an upgrade is actually needed - the rest
+// of the output is an unconditional action trace (component "update"
+// steps, manifest-annotation diffs) that appears even when the detected
+// version already matches the target, so it's not usable as a drift
+// signal on its own. Returns "" if the line isn't found (output format
+// changed, or --from somehow wasn't auto-detected).
+func ParseKubernetesVersion(dryRunOutput string) string {
+	m := detectedKubernetesVersionRE.FindStringSubmatch(dryRunOutput)
+	if m == nil {
+		return ""
+	}
+
+	return m[1]
+}
+
+// ImageTag returns the tag component of an OCI image reference ref: the
+// substring after the last colon, but only when that colon comes after
+// the last slash - a colon before the last slash is a registry port (e.g.
+// "registry:5000/image"), not a tag separator. Returns "" if ref has no
+// parseable tag (digest reference, or ref itself is "").
+func ImageTag(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	// A digest suffix (@sha256:...) has its own colon that isn't a tag
+	// separator - strip it before hunting for one.
+	if at := strings.LastIndex(ref, "@"); at >= 0 {
+		ref = ref[:at]
+	}
+
+	lastColon := strings.LastIndex(ref, ":")
+	lastSlash := strings.LastIndex(ref, "/")
+
+	if lastColon <= lastSlash {
+		return ""
+	}
+
+	return ref[lastColon+1:]
+}
+
+// TalosVersionDrift reports whether a node's currently-running Talos OS
+// version (running, e.g. "v1.13.7") differs from the version tag of its
+// rendered target install image (targetImage, machine.install.image).
+// ok=false means "nothing to compare, not a drift candidate" - targetImage
+// is "" (nothing configured; left for patches to set) or has no
+// parseable tag - not an error.
+func TalosVersionDrift(running, targetImage string) (drifted, ok bool) {
+	target := ImageTag(targetImage)
+	if target == "" {
+		return false, false
+	}
+
+	normalize := func(v string) string { return "v" + strings.TrimPrefix(v, "v") }
+
+	return normalize(running) != normalize(target), true
+}
+
+// ExtensionDrift compares installed extension names against desired
+// (schematic officialExtensions entries), matching on the suffix after
+// the last "/" on both sides - so "siderolabs/zfs" and "zfs" compare
+// equal regardless of which format either side reports. missing = desired
+// but not installed; unexpected = installed but not desired. Both empty
+// means no drift.
+func ExtensionDrift(installed, desired []string) (missing, unexpected []string) {
+	installedShort := make(map[string]bool, len(installed))
+	for _, name := range installed {
+		installedShort[extensionShortName(name)] = true
+	}
+
+	desiredShort := make(map[string]bool, len(desired))
+	for _, name := range desired {
+		desiredShort[extensionShortName(name)] = true
+	}
+
+	for _, name := range desired {
+		if !installedShort[extensionShortName(name)] {
+			missing = append(missing, name)
+		}
+	}
+
+	for _, name := range installed {
+		if !desiredShort[extensionShortName(name)] {
+			unexpected = append(unexpected, name)
+		}
+	}
+
+	return missing, unexpected
+}
+
+func extensionShortName(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+
+	return name
+}
+
+// KernelArgDrift reports which of desired's extraKernelArgs entries are
+// absent from cmdline (the live /proc/cmdline), matched as
+// whitespace-delimited tokens. Only checks for missing entries - cmdline
+// always contains Talos/kernel boilerplate no schematic declares, so
+// "extra" isn't a meaningful signal here (unlike extensions, where the
+// schematic is the sole source of truth for what's installed).
+func KernelArgDrift(cmdline string, desired []string) (missing []string) {
+	tokens := make(map[string]bool)
+	for tok := range strings.FieldsSeq(cmdline) {
+		tokens[tok] = true
+	}
+
+	for _, arg := range desired {
+		if !tokens[arg] {
+			missing = append(missing, arg)
+		}
+	}
+
+	return missing
+}

--- a/internal/talos/drift_test.go
+++ b/internal/talos/drift_test.go
@@ -1,0 +1,181 @@
+package talos_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/mirceanton/talstomize/internal/talos"
+)
+
+func TestImageTag(t *testing.T) {
+	for name, tc := range map[string]struct {
+		ref  string
+		want string
+	}{
+		"bare tag":                 {"ghcr.io/siderolabs/installer:v1.13.8", "v1.13.8"},
+		"schematic image with tag": {"factory.talos.dev/metal-installer/abc123:v1.13.8", "v1.13.8"},
+		"registry port, no tag":    {"registry:5000/image", ""},
+		"registry port, with tag":  {"registry:5000/image:v1.0.0", "v1.0.0"},
+		"digest reference":         {"ghcr.io/siderolabs/installer@sha256:abcdef", ""},
+		"empty":                    {"", ""},
+		"no colon at all":          {"ghcr.io/siderolabs/installer", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := talos.ImageTag(tc.ref); got != tc.want {
+				t.Errorf("ImageTag(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTalosVersionDrift(t *testing.T) {
+	for name, tc := range map[string]struct {
+		running, targetImage string
+		wantDrifted, wantOK  bool
+	}{
+		"match, both with v prefix": {
+			running: "v1.13.8", targetImage: "ghcr.io/siderolabs/installer:v1.13.8",
+			wantDrifted: false, wantOK: true,
+		},
+		"match, running without v prefix": {
+			running: "1.13.8", targetImage: "ghcr.io/siderolabs/installer:v1.13.8",
+			wantDrifted: false, wantOK: true,
+		},
+		"mismatch": {
+			running: "v1.13.7", targetImage: "ghcr.io/siderolabs/installer:v1.13.8",
+			wantDrifted: true, wantOK: true,
+		},
+		"empty target image": {
+			running: "v1.13.7", targetImage: "",
+			wantDrifted: false, wantOK: false,
+		},
+		"untagged target image": {
+			running: "v1.13.7", targetImage: "ghcr.io/siderolabs/installer@sha256:abcdef",
+			wantDrifted: false, wantOK: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			drifted, ok := talos.TalosVersionDrift(tc.running, tc.targetImage)
+			if drifted != tc.wantDrifted || ok != tc.wantOK {
+				t.Errorf("TalosVersionDrift(%q, %q) = (%v, %v), want (%v, %v)",
+					tc.running, tc.targetImage, drifted, ok, tc.wantDrifted, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestExtensionDrift(t *testing.T) {
+	for name, tc := range map[string]struct {
+		installed, desired     []string
+		wantMissing, wantExtra []string
+	}{
+		"exact match": {
+			installed: []string{"siderolabs/zfs", "siderolabs/nvidia-container-toolkit-production"},
+			desired:   []string{"siderolabs/zfs", "siderolabs/nvidia-container-toolkit-production"},
+		},
+		"short vs qualified names still match": {
+			installed: []string{"zfs", "nvidia-container-toolkit-production"},
+			desired:   []string{"siderolabs/zfs", "siderolabs/nvidia-container-toolkit-production"},
+		},
+		"missing one": {
+			installed:   []string{"siderolabs/zfs"},
+			desired:     []string{"siderolabs/zfs", "siderolabs/qemu-guest-agent"},
+			wantMissing: []string{"siderolabs/qemu-guest-agent"},
+		},
+		"unexpected one": {
+			installed: []string{"siderolabs/zfs", "siderolabs/qemu-guest-agent"},
+			desired:   []string{"siderolabs/zfs"},
+			wantExtra: []string{"siderolabs/qemu-guest-agent"},
+		},
+		"both directions": {
+			installed:   []string{"siderolabs/zfs"},
+			desired:     []string{"siderolabs/nvidia-container-toolkit-production"},
+			wantMissing: []string{"siderolabs/nvidia-container-toolkit-production"},
+			wantExtra:   []string{"siderolabs/zfs"},
+		},
+		"nothing desired, nothing installed": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			missing, extra := talos.ExtensionDrift(tc.installed, tc.desired)
+			if !slices.Equal(missing, tc.wantMissing) {
+				t.Errorf("ExtensionDrift(...) missing = %v, want %v", missing, tc.wantMissing)
+			}
+			if !slices.Equal(extra, tc.wantExtra) {
+				t.Errorf("ExtensionDrift(...) unexpected = %v, want %v", extra, tc.wantExtra)
+			}
+		})
+	}
+}
+
+func TestParseKubernetesVersion(t *testing.T) {
+	for name, tc := range map[string]struct {
+		output string
+		want   string
+	}{
+		// Captured verbatim from a real `talosctl upgrade-k8s --dry-run` run.
+		"real dry-run output, no-op case": {
+			output: `automatically detected the lowest Kubernetes version 1.36.3
+discovered controlplane nodes ["10.0.0.15"]
+discovered worker nodes []
+> "10.0.0.15": Talos version 1.13.7 is compatible with Kubernetes version 1.36.3
+updating "kube-apiserver" to version "1.36.3"
+`,
+			want: "1.36.3",
+		},
+		"real dry-run output, unsupported path error still has the line": {
+			output: `automatically detected the lowest Kubernetes version 1.36.3
+unsupported upgrade path 1.36->1.35 (from "1.36.3" to "1.35.0")
+`,
+			want: "1.36.3",
+		},
+		"line not present (format changed, or unparseable)": {
+			output: "some unrelated output\n",
+			want:   "",
+		},
+		"empty": {
+			output: "",
+			want:   "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := talos.ParseKubernetesVersion(tc.output); got != tc.want {
+				t.Errorf("ParseKubernetesVersion(...) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKernelArgDrift(t *testing.T) {
+	const cmdline = "talos.platform=metal console=ttyS0 cpufreq.default_governor=performance init_on_alloc=1"
+
+	for name, tc := range map[string]struct {
+		desired []string
+		want    []string
+	}{
+		"all present": {
+			desired: []string{"cpufreq.default_governor=performance", "console=ttyS0"},
+		},
+		"one missing": {
+			desired: []string{"cpufreq.default_governor=performance", "amdgpu.gttsize=40960"},
+			want:    []string{"amdgpu.gttsize=40960"},
+		},
+		"all missing": {
+			desired: []string{"amdgpu.gttsize=40960", "some.other.arg=1"},
+			want:    []string{"amdgpu.gttsize=40960", "some.other.arg=1"},
+		},
+		"empty desired list": {},
+		"substring should not falsely match": {
+			// "governor" alone should not be considered present just
+			// because it appears inside "cpufreq.default_governor=performance".
+			desired: []string{"governor"},
+			want:    []string{"governor"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := talos.KernelArgDrift(cmdline, tc.desired)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("KernelArgDrift(cmdline, %v) = %v, want %v", tc.desired, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/talos/engine.go
+++ b/internal/talos/engine.go
@@ -25,9 +25,10 @@ import (
 
 // Engine renders per-node Talos machine configs from a talstomize Config.
 type Engine struct {
-	cfg          *tstomcfg.Config
-	input        *generate.Input
-	talosVersion string
+	cfg               *tstomcfg.Config
+	input             *generate.Input
+	talosVersion      string
+	kubernetesVersion string
 
 	// resolveSchematic posts a schematic customization to the Image
 	// Factory and returns its ID; defaults to factory.Schematic, swappable
@@ -88,7 +89,22 @@ func NewEngine(cfg *tstomcfg.Config) (*Engine, error) {
 		talosVersion = tversion.Tag
 	}
 
-	return &Engine{cfg: cfg, input: input, talosVersion: talosVersion, resolveSchematic: factory.Schematic}, nil
+	return &Engine{
+		cfg:               cfg,
+		input:             input,
+		talosVersion:      talosVersion,
+		kubernetesVersion: kubernetesVersion,
+		resolveSchematic:  factory.Schematic,
+	}, nil
+}
+
+// KubernetesVersion returns the Kubernetes version every node's config is
+// rendered against (Config.KubernetesVersion, defaulted to
+// constants.DefaultKubernetesVersion when unset, with any leading "v"
+// stripped) - the same value already baked into every rendered machine
+// config, not a second source of truth.
+func (e *Engine) KubernetesVersion() string {
+	return e.kubernetesVersion
 }
 
 // Talosconfig returns the talosctl client configuration for the cluster,
@@ -135,6 +151,36 @@ func (e *Engine) effectiveInstallImage(node tstomcfg.Node) (string, error) {
 	default:
 		return "", nil
 	}
+}
+
+// EffectiveCustomization returns the parsed schematic customization
+// (extra kernel args + desired system extensions) effective for node,
+// mirroring effectiveInstallImage's precedence: node's own
+// installer.schematic, else the cluster-wide one. ok is false when
+// neither is set, or when a literal installer.image is used instead -
+// there's nothing to compare extensions/kernel args against in that case,
+// same "left for patches" reasoning as effectiveInstallImage's "" result.
+func (e *Engine) EffectiveCustomization(node tstomcfg.Node) (customization factory.Customization, ok bool, err error) {
+	var schematic yaml.Node
+
+	switch {
+	case node.Installer.Image != "":
+		return factory.Customization{}, false, nil
+	case node.Installer.SchematicSet():
+		schematic = node.Installer.Schematic
+	case e.cfg.Installer.Image != "":
+		return factory.Customization{}, false, nil
+	case e.cfg.Installer.SchematicSet():
+		schematic = e.cfg.Installer.Schematic
+	default:
+		return factory.Customization{}, false, nil
+	}
+
+	if err := schematic.Decode(&customization); err != nil {
+		return factory.Customization{}, false, fmt.Errorf("parsing schematic: %w", err)
+	}
+
+	return customization, true, nil
 }
 
 // resolveSchematicImage posts schematic to the Image Factory (memoized, so

--- a/internal/talos/engine_test.go
+++ b/internal/talos/engine_test.go
@@ -349,6 +349,75 @@ workerPatches: []
 	}
 }
 
+func TestEngineKubernetesVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	writeSecretsBundle(t, dir)
+
+	writeFile(t, filepath.Join(dir, "talstomize.yaml"), `
+apiVersion: config.talstomize.dev/v1alpha1
+kind: Talstomize
+clusterName: test-cluster
+controlPlaneEndpoint: https://10.5.0.2:6443
+secrets: ./talos-secrets.yaml
+kubernetesVersion: v1.36.3
+nodes:
+  nodea:
+    ip: 10.5.0.11
+    kind: controlplane
+controlplanePatches: []
+workerPatches: []
+`)
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	engine, err := talos.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if got, want := engine.KubernetesVersion(), "1.36.3"; got != want {
+		t.Errorf("KubernetesVersion() = %q, want %q (leading v stripped)", got, want)
+	}
+}
+
+func TestEngineKubernetesVersionDefault(t *testing.T) {
+	dir := t.TempDir()
+
+	writeSecretsBundle(t, dir)
+
+	writeFile(t, filepath.Join(dir, "talstomize.yaml"), `
+apiVersion: config.talstomize.dev/v1alpha1
+kind: Talstomize
+clusterName: test-cluster
+controlPlaneEndpoint: https://10.5.0.2:6443
+secrets: ./talos-secrets.yaml
+nodes:
+  nodea:
+    ip: 10.5.0.11
+    kind: controlplane
+controlplanePatches: []
+workerPatches: []
+`)
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	engine, err := talos.NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if got, want := engine.KubernetesVersion(), "1.36.2"; got != want {
+		t.Errorf("KubernetesVersion() = %q, want default %q", got, want)
+	}
+}
+
 func TestEngineTalosconfig(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/talos/schematic_test.go
+++ b/internal/talos/schematic_test.go
@@ -2,6 +2,7 @@ package talos
 
 import (
 	"errors"
+	"slices"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -145,6 +146,119 @@ func TestEffectiveInstallImageSchematicError(t *testing.T) {
 	if _, err := e.effectiveInstallImage(tstomcfg.Node{}); err == nil {
 		t.Fatal("effectiveInstallImage: expected an error, got nil")
 	}
+}
+
+func TestEffectiveCustomizationNodeSchematic(t *testing.T) {
+	e := &Engine{cfg: &tstomcfg.Config{}}
+
+	node := tstomcfg.Node{
+		Installer: tstomcfg.NodeInstaller{
+			Schematic: yamlNode(t, "customization:\n  extraKernelArgs: [foo=1]\n  systemExtensions:\n    officialExtensions: [siderolabs/zfs]\n"),
+		},
+	}
+
+	got, ok, err := e.EffectiveCustomization(node)
+	if err != nil {
+		t.Fatalf("EffectiveCustomization: %v", err)
+	}
+
+	if !ok {
+		t.Fatal("EffectiveCustomization: ok = false, want true")
+	}
+
+	if want := []string{"foo=1"}; !slices.Equal(got.Customization.ExtraKernelArgs, want) {
+		t.Errorf("ExtraKernelArgs = %v, want %v", got.Customization.ExtraKernelArgs, want)
+	}
+
+	if want := []string{"siderolabs/zfs"}; !slices.Equal(got.Customization.SystemExtensions.OfficialExtensions, want) {
+		t.Errorf("OfficialExtensions = %v, want %v", got.Customization.SystemExtensions.OfficialExtensions, want)
+	}
+}
+
+func TestEffectiveCustomizationClusterSchematic(t *testing.T) {
+	e := &Engine{
+		cfg: &tstomcfg.Config{
+			Installer: tstomcfg.Installer{
+				Schematic: yamlNode(t, "customization:\n  systemExtensions:\n    officialExtensions: [siderolabs/zfs]\n"),
+			},
+		},
+	}
+
+	got, ok, err := e.EffectiveCustomization(tstomcfg.Node{})
+	if err != nil {
+		t.Fatalf("EffectiveCustomization: %v", err)
+	}
+
+	if !ok {
+		t.Fatal("EffectiveCustomization: ok = false, want true")
+	}
+
+	if want := []string{"siderolabs/zfs"}; !slices.Equal(got.Customization.SystemExtensions.OfficialExtensions, want) {
+		t.Errorf("OfficialExtensions = %v, want %v", got.Customization.SystemExtensions.OfficialExtensions, want)
+	}
+}
+
+func TestEffectiveCustomizationNodeSchematicOverridesCluster(t *testing.T) {
+	e := &Engine{
+		cfg: &tstomcfg.Config{
+			Installer: tstomcfg.Installer{
+				Schematic: yamlNode(t, "customization:\n  systemExtensions:\n    officialExtensions: [siderolabs/zfs]\n"),
+			},
+		},
+	}
+
+	node := tstomcfg.Node{
+		Installer: tstomcfg.NodeInstaller{
+			Schematic: yamlNode(t, "customization:\n  systemExtensions:\n    officialExtensions: [siderolabs/nvidia-container-toolkit-production]\n"),
+		},
+	}
+
+	got, ok, err := e.EffectiveCustomization(node)
+	if err != nil {
+		t.Fatalf("EffectiveCustomization: %v", err)
+	}
+
+	if !ok {
+		t.Fatal("EffectiveCustomization: ok = false, want true")
+	}
+
+	want := []string{"siderolabs/nvidia-container-toolkit-production"}
+	if !slices.Equal(got.Customization.SystemExtensions.OfficialExtensions, want) {
+		t.Errorf("OfficialExtensions = %v, want %v (node schematic should win)", got.Customization.SystemExtensions.OfficialExtensions, want)
+	}
+}
+
+func TestEffectiveCustomizationLiteralImageNoSchematic(t *testing.T) {
+	for name, node := range map[string]tstomcfg.Node{
+		"node installer.image": {Installer: tstomcfg.NodeInstaller{Image: "ghcr.io/siderolabs/installer:v1.13.8"}},
+		"nothing set":          {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			e := &Engine{cfg: &tstomcfg.Config{}}
+
+			_, ok, err := e.EffectiveCustomization(node)
+			if err != nil {
+				t.Fatalf("EffectiveCustomization: %v", err)
+			}
+
+			if ok {
+				t.Error("EffectiveCustomization: ok = true, want false (no schematic to compare against)")
+			}
+		})
+	}
+
+	t.Run("cluster-wide installer.image, no schematic anywhere", func(t *testing.T) {
+		e := &Engine{cfg: &tstomcfg.Config{Installer: tstomcfg.Installer{Image: "ghcr.io/siderolabs/installer:v1.13.8"}}}
+
+		_, ok, err := e.EffectiveCustomization(tstomcfg.Node{})
+		if err != nil {
+			t.Fatalf("EffectiveCustomization: %v", err)
+		}
+
+		if ok {
+			t.Error("EffectiveCustomization: ok = true, want false (no schematic to compare against)")
+		}
+	})
 }
 
 func TestResolveSchematicImageMemoizes(t *testing.T) {


### PR DESCRIPTION
## Summary
- `talstomize diff` now compares live cluster state against what's configured, on top of its existing machine-config diff: the node's actually-booted Talos OS version, its installed system extensions and kernel args (when `installer.schematic` is set), and the cluster's running Kubernetes version.
- Closes a real gap: bumping `talosVersion`/`kubernetesVersion`/`installer.schematic` and running `apply` only changes what gets *rendered* - a plain machine-config diff can't catch a pending upgrade either, since the rendered and running config can already agree on the target `install.image` even when the node was never actually rebooted onto it.
- `diff` never executes an upgrade itself - `talosctl upgrade`/`upgrade-k8s` stays a deliberate, manual step.

## Notable fixes found via testing against a real running node
- Talos auto-generates two synthetic pseudo-extension entries (`schematic`, `modules.dep`) on every node regardless of what's declared; without filtering these the extension-drift check would flag them as "unexpected" universally.
- `upgrade-k8s --dry-run` doesn't cleanly signal "nothing to do" - it unconditionally prints component-update traces and manifest-annotation diffs even when the cluster is already at the target version. Rewritten to parse the one reliable signal in that output (the auto-detected current version) instead of treating any non-empty output as drift.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `golangci-lint run ./...` - 0 issues
- [x] `go test ./...` - full suite green, including new hermetic tests for `ImageTag`/`TalosVersionDrift`/`ExtensionDrift`/`KernelArgDrift`/`ParseKubernetesVersion`, `EffectiveCustomization` precedence, and extension-name parsing built from real captured `talosctl get extensions` output
- [x] `scripts/test.sh` e2e smoke test against `examples/simple`
- [x] Manually verified against a real running Talos node: correctly reported genuine Talos OS version drift, correctly stayed silent when extensions/kernel-args/Kubernetes version were already in sync, correct exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWyLSUmh1A461RhYoKgz4b