### PR TITLE
chore(renovate): group talos mise and go dependency updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,6 +6,10 @@
             "matchDepNames": [ "go" ],
             "matchDatasources": [ "golang-version", "go" ],
             "groupName": "go"
+        },
+        {
+            "matchDepNames": [ "aqua:siderolabs/talos", "github.com/siderolabs/talos/pkg/machinery" ],
+            "groupName": "talos"
         }
     ]
 }


### PR DESCRIPTION
The aqua:siderolabs/talos mise tool and the go.mod
github.com/siderolabs/talos/pkg/machinery module track the same
upstream Talos release, so bump them together in one PR instead of
two separate renovate PRs.