### PR TITLE
Update `examples/simple` configuration to follow Talos 1.14 standards

### DIFF
--- a/examples/simple/patches/controlplane-common.yaml
+++ b/examples/simple/patches/controlplane-common.yaml
@@ -1,2 +1,5 @@
-cluster:
-  allowSchedulingOnControlPlanes: true
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+taints:
+  node-role.kubernetes.io/control-plane:
+    $patch: delete

--- a/examples/simple/talstomize.yaml
+++ b/examples/simple/talstomize.yaml
@@ -24,12 +24,12 @@ nodes:
     kind: worker
     patches:
       - machine:
-          kubelet:
-            extraMounts:
-              - destination: /var/lib/longhorn
-                type: bind
-                source: /var/lib/longhorn
-                options: ["bind", "rshared", "rw"]
+          install:
+            disk: "/dev/nvme0n1"
+      - machine:
+          time:
+            servers:
+              - time.cloudflare.com
 
 patches:
   - machine:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,20 +39,25 @@ echo "====> Validating nodea (controlplane) got its hostname, cluster-wide, per-
 assert_set examples/simple/_out/nodea.yaml "hostname: nodea"
 assert_set examples/simple/_out/nodea.yaml "net.core.somaxconn:"
 assert_set examples/simple/_out/nodea.yaml "disk: /dev/sda"
-assert_set examples/simple/_out/nodea.yaml "allowSchedulingOnControlPlanes: true"
+assert_unset examples/simple/_out/nodea.yaml "taints:"
 assert_set examples/simple/_out/nodea.yaml "image: factory.talos.dev/metal-installer/abc123:v1.9.5"
 assert_unset examples/simple/_out/nodea.yaml "image: ghcr.io/siderolabs/installer:v1.9.5"
 
 echo "====> Validating nodeb (worker) got its hostname, cluster-wide, and inline patch, but not nodea's, and fell back to the cluster-wide installImage..."
 assert_set examples/simple/_out/nodeb.yaml "hostname: nodeb"
 assert_set examples/simple/_out/nodeb.yaml "net.core.somaxconn:"
-assert_set examples/simple/_out/nodeb.yaml "destination: /var/lib/longhorn"
+assert_set examples/simple/_out/nodeb.yaml "- time.cloudflare.com"
+assert_set examples/simple/_out/nodeb.yaml "disk: /dev/nvme0n1"
 assert_unset examples/simple/_out/nodeb.yaml "disk: /dev/sda"
 assert_set examples/simple/_out/nodeb.yaml "image: ghcr.io/siderolabs/installer:v1.9.5"
 
 echo "====> Validating a talosctl client config was generated too..."
 assert_set examples/simple/_out/talosconfig "context: home-cluster"
 assert_set examples/simple/_out/talosconfig "10.5.0.11"
+
+echo "====> Validating node configuration using talosctl..."
+talosctl validate -m metal -c examples/simple/_out/nodea.yaml
+talosctl validate -m metal -c examples/simple/_out/nodeb.yaml
 
 echo "========================================================================================="
 echo "Tests completed successfully!"


### PR DESCRIPTION
The current `examples/simple` configuration doesn't create valid configurations under Talos 1.14.0 standards. This MR aims to fix that to reduce confusion when new users try the tool with this example configuration.

## `.cluster.allowSchedulingOnControlPlanes`

The `.cluster.allowSchedulingOnControlPlanes` configuration has been deprecated and Talos now sets a taint on the nodes, which can be removed using a patch to then enable scheduling on control planes. More information available at [docs.siderolabs.com/deploy-and-manage-workloads/workloads-on-controlplane](https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane#enable-workloads-on-your-control-plane-nodes)

In its place, I've used the new `KubeNodeConfig` equivalent, which basically patches the configuration to remove the `node-role.kubernetes.io/control-plane` taint, as instructed in [docs.siderolabs.com/deploy-and-manage-workloads/workloads-on-controlplane](https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane#enable-workloads-on-your-control-plane-nodes). The test now looks for the absence of the `taints` string in the `nodea` configuration.

## `.machine.kubelet.extraMounts` 

The `.machine.kubelet.extraMounts` configuration has been deprecated and is no longer needed. Providing a `UserVolumeConfig` is sufficient and doesn't require the `extraMounts` to propagate said volume inside of the Kubelet container. This is also described in the [Talos Longhorn installation guide](https://docs.siderolabs.com/kubernetes-guides/csi/longhorn) and in this comment https://github.com/siderolabs/talos/issues/13053#issuecomment-4154513264.

As this setting doesn't exist anymore, I replaced it with a `machine.time.servers` instead and updated the tests accordingly.

## `talosctl validate` usage

To make sure this issue is caught earlier in the future, I also added a `talosctl validate` step in the tests to validate both `nodea` and `nodeb` configurations using the official Talos CLI.

Please let me know if there's any issue with this MR or if you have any question :smile: 